### PR TITLE
Fix for conversion of nil to String

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -78,7 +78,7 @@ class JobsController < ApplicationController
       if @position.save
         user = User.find(@position.user_id)
         job = Job.find(@position.job_id)
-        flash[:success] = user.first_name + ' ' + user.last_name + ' assigned as ' + job.title + ' from ' + @position.start_date.to_date.to_s + ' to ' + @position.end_date.to_date.to_s
+	flash[:success] = user.first_name.to_s + ' ' + user.last_name.to_s + ' assigned as ' + job.title.to_s + ' from ' + @position.start_date.to_date.to_s + ' to ' + @position.end_date.to_date.to_s
         redirect_to :back
       else
         flash.keep[:danger] = 'Could Not Save Position'

--- a/app/views/interviews/_calendar.html.erb
+++ b/app/views/interviews/_calendar.html.erb
@@ -40,7 +40,7 @@
                 <tr>
                   <td><%= interview.job_application.id %></td>
                   <td><%= link_to interview.job_application.job_posting.title, interview.job_application.job_posting %></td>
-                  <td><%= link_to interview.job_application.user.first_name + " " + interview.job_application.user.last_name, interview.job_application %></td>
+                  <td><%= link_to interview.job_application.user.first_name.to_s + " " + interview.job_application.user.last_name.to_s, interview.job_application %></td>
                   <td><%= interview.start_time.strftime("%b %e, %l:%M %p") %></td>
                   <td><%= interview.end_time.strftime("%b %e, %l:%M %p") %></td>
                   <td>

--- a/app/views/organizations/_active_positions.html.erb
+++ b/app/views/organizations/_active_positions.html.erb
@@ -6,7 +6,7 @@
           <%= link_to pos.job.title.titleize, job_path(:id => job.id) %>
         </td>
         <td>
-          <%= link_to pos.user.first_name + " " + pos.user.last_name, profile_path(pos.user.id) %>
+          <%= link_to pos.user.first_name.to_s + " " + pos.user.last_name.to_s, profile_path(pos.user.id) %>
         </td>
         <td>
           <%= pos.user.email %>


### PR DESCRIPTION
Fixes: #79 

## Proposed Change
Fix to bug that throws the following error:
No implicit conversion of nil into String

Below are some images that show case the bug on some different pages:
![image](https://user-images.githubusercontent.com/32376872/46423981-e412c780-c705-11e8-8a16-1ca773f5f018.png)
![image](https://user-images.githubusercontent.com/32376872/46424000-f260e380-c705-11e8-8026-d0487104b7e1.png)
This also fixes the same error thrown in issue #79 

### How did you do this?
The issue seems to be cause by accounts where the first or last name is not defined. Ruby does not implicitly convert these to an empty string so the fix is to use the `to_s` function so first and last name are explicitly converted.

### Why are you choosing this approach?
After some research on Google and StackOverflow, the consensus for this error message seems to be converting it explicitly:
https://stackoverflow.com/questions/27817679/no-implicit-conversion-of-nil-into-string-error

### Any open questions you want to ask code reviewers?
Is this the best way to solve this problem? I am unfamiliar with Ruby and realize there may be other approaches to solve this issue. If you can think of a better way to handle this, please let me know!

It is also worth noting that this problem probably exists undiscovered on more pages and should be fixed as they come to light.

### List of changes:

  - Convert users firstname and lastname to strings explicitly with `to_s`  in:
     -app/controllers/job_controller.rb
     -app/views/organizations/_active_positions.html.erb
     -app/views/interviews/_calendar.html.erb

## Pull Request Checklist:

  - [ ] My submission passes all tests.
  - [x] I have lint my code locally prior to submission.
  - [x] I have written new tests for my core changes (where applicable).
  - [x] I have referenced all useful information (issues, tasks, etc) in the pull request.

